### PR TITLE
[Fix] Fixing ForAgainst debate type on Heroku

### DIFF
--- a/routes/router.js
+++ b/routes/router.js
@@ -90,7 +90,7 @@ router.get('/:debateId', async (req, res) => {
     /* eslint-disable global-require */
 
     const modulePath = path.resolve(
-      `${listing.getRootDir()}/modules/${debate.debateType}`,
+      `${listing.getRootDir()}/modules/${debate.debateType.toLowerCase()}`,
     );
     const moduleType = require(modulePath);
 


### PR DESCRIPTION
## Description

Fixes an attempt to load camelcase modules by setting the request string to lower case

## Implementation

Sets module request string to lower case

## Screenshot

n/a

## .env changes

n/a

## Additional requirements

n/a
