### PR TITLE
[Feature] Debate type dashboard

### DIFF
--- a/models/dynamoDb.js
+++ b/models/dynamoDb.js
@@ -312,13 +312,17 @@ async function createDebateType({
 	displayName,
 	createdBy
 }) {
+	const createdAt = date;
+	const updatedAt = date;
 	const params = {
 		Item: {
 			name,
 			description,
 			specialUsers,
 			displayName,
-			createdBy
+			createdBy,
+			createdAt,
+			updatedAt
 		}
 	};
 
@@ -367,7 +371,13 @@ async function getAllDebateTypes() {
 			process.env.DEBATE_TYPE_TABLE
 		);
 		if (queryStatement.result) {
-			return queryStatement.result;
+			let debateTypes = [];
+			queryStatement.result['Items'].forEach((item) => {
+				item.formatDate = Utils.formatDate(item.createdAt);
+				console.log(item);
+				debateTypes.push(item);
+			});
+			return debateTypes;
 		}
 		throw new Error('No result');
 	} catch (err) {

--- a/models/dynamoDb.js
+++ b/models/dynamoDb.js
@@ -310,10 +310,18 @@ async function createDebateType({
 	description,
 	specialUsers,
 	displayName,
-	createdBy
+	createdBy,
+	createdAt = null
 }) {
-	const createdAt = date;
+	const date = new Date().getTime();
 	const updatedAt = date;
+
+	if (createdAt === null) {
+		createdAt = date;
+	} else {
+		createdAt = Number(createdAt);
+	}
+
 	const params = {
 		Item: {
 			name,

--- a/models/dynamoDb.js
+++ b/models/dynamoDb.js
@@ -374,7 +374,6 @@ async function getAllDebateTypes() {
 			let debateTypes = [];
 			queryStatement.result['Items'].forEach((item) => {
 				item.formatDate = Utils.formatDate(item.createdAt);
-				console.log(item);
 				debateTypes.push(item);
 			});
 			return debateTypes;

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -168,6 +168,21 @@ router.post('/edit/:debateId', async (req, res) => {
 	}
 });
 
+router.get('/list', async (req, res) => {
+	const username = getS3oUsername(req.cookies);
+
+	try {
+		const debateList = await dynamoDb.getAllDebateLists();
+		res.render('admin/listDebates', {
+			username,
+			debateList,
+			page: 'debates'
+		});
+	} catch (err) {
+		res.status(404).send("Sorry can't find that!");
+	}
+});
+
 function formatSpecialUsers(specialUsers) {
 	let specialUsersFormatted = [];
 	Object.keys(specialUsers).forEach((userType) => {

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -142,10 +142,10 @@ router.get('/list', async (req, res) => {
 	const username = getS3oUsername(req.cookies);
 
 	try {
-		const debateList = await dynamoDb.getAllDebateLists();
+		const debateTypeList = await dynamoDb.getAllDebateTypes();
 		res.render('admin/listDebateTypes', {
 			username,
-			debateList,
+			debateTypeList: debateTypeList,
 			page: 'debateTypes'
 		});
 	} catch (err) {

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -138,6 +138,23 @@ router.post('/edit/:debateName', async (req, res) => {
 	}
 });
 
+router.get('/list/:debateName', async (req, res) => {
+	const username = getS3oUsername(req.cookies);
+
+	try {
+		const { debateName } = req.params;
+		const debatesByType = await dynamoDb.getAllDebateLists();
+
+		res.render('admin/listDebatesByType', {
+			username,
+			debatesByType: debatesByType[debateName],
+			page: 'debatesByType'
+		});
+	} catch (err) {
+		res.status(404).send("Sorry can't find that!");
+	}
+});
+
 router.get('/list', async (req, res) => {
 	const username = getS3oUsername(req.cookies);
 

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -138,6 +138,21 @@ router.post('/edit/:debateName', async (req, res) => {
 	}
 });
 
+router.get('/list', async (req, res) => {
+	const username = getS3oUsername(req.cookies);
+
+	try {
+		const debateList = await dynamoDb.getAllDebateLists();
+		res.render('admin/listDebateTypes', {
+			username,
+			debateList,
+			page: 'debateTypes'
+		});
+	} catch (err) {
+		res.status(404).send("Sorry can't find that!");
+	}
+});
+
 function getAlertMessage(alertType, action) {
 	switch (alertType) {
 		case 'success':

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -71,12 +71,12 @@ router.post('/create', async (req, res) => {
 	}
 });
 
-router.get('/edit/:debateName', async (req, res) => {
+router.get('/edit/:debateTypeName', async (req, res) => {
 	try {
 		const { alertType, alertAction } = req.query;
 		const username = getS3oUsername(req.cookies);
-		const { debateName } = req.params;
-		const debateType = await dynamoDb.getDebateType(debateName);
+		const { debateTypeName } = req.params;
+		const debateType = await dynamoDb.getDebateType(debateTypeName);
 		if (debateType.Items.length === 0) {
 			throw new Error('Cant find debate type');
 		}
@@ -117,7 +117,7 @@ router.get('/edit/:debateName', async (req, res) => {
 	}
 });
 
-router.post('/edit/:debateName', async (req, res) => {
+router.post('/edit/:debateTypeName', async (req, res) => {
 	try {
 		const {
 			specialUsers,
@@ -126,11 +126,11 @@ router.post('/edit/:debateName', async (req, res) => {
 			createdAt,
 			createdBy
 		} = req.body;
-		const { debateName } = req.params;
+		const { debateTypeName } = req.params;
 
 		const result = await dynamoDb.createDebateType({
 			specialUsers,
-			name: debateName,
+			name: debateTypeName,
 			description,
 			displayName,
 			createdAt,
@@ -140,26 +140,26 @@ router.post('/edit/:debateName', async (req, res) => {
 			throw new Error(result.error);
 		}
 		res.redirect(
-			`/admin/debate_type/edit/${debateName}?alertType=success&alertAction=editing`
+			`/admin/debate_type/edit/${debateTypeName}?alertType=success&alertAction=editing`
 		);
 	} catch (err) {
 		console.error(err);
 		res.redirect(
-			`/admin/debate_type/edit/${debateName}?alertType=error&alertAction=editing`
+			`/admin/debate_type/edit/${debateTypeName}?alertType=error&alertAction=editing`
 		);
 	}
 });
 
-router.get('/list/:debateName', async (req, res) => {
+router.get('/list/:debateTypeName', async (req, res) => {
 	const username = getS3oUsername(req.cookies);
 
 	try {
-		const { debateName } = req.params;
+		const { debateTypeName } = req.params;
 		const debatesByType = await dynamoDb.getAllDebateLists();
 
 		res.render('admin/listDebatesByType', {
 			username,
-			debatesByType: debatesByType[debateName],
+			debatesByType: debatesByType[debateTypeName],
 			page: 'debatesByType'
 		});
 	} catch (err) {

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -1,6 +1,7 @@
 const express = require('express');
 
 const router = express.Router();
+const Utils = require('../../helpers/utils');
 const dynamoDb = require('../../models/dynamoDb');
 const { getS3oUsername } = require('../../helpers/cookies');
 
@@ -84,7 +85,8 @@ router.get('/edit/:debateName', async (req, res) => {
 			name,
 			specialUsers,
 			displayName,
-			createdBy
+			createdBy,
+			createdAt
 		} = debateType.Items[0];
 
 		res.render('admin/editDebateType', {
@@ -93,6 +95,8 @@ router.get('/edit/:debateName', async (req, res) => {
 			name,
 			displayName,
 			createdBy,
+			createdAt,
+			formatDate: Utils.formatDate(Number(createdAt)),
 			specialUsers: specialUsers.map((specialUser, index) => ({
 				...specialUser,
 				index
@@ -115,14 +119,22 @@ router.get('/edit/:debateName', async (req, res) => {
 
 router.post('/edit/:debateName', async (req, res) => {
 	try {
-		const { specialUsers, name, description, displayName } = req.body;
+		const {
+			specialUsers,
+			description,
+			displayName,
+			createdAt,
+			createdBy
+		} = req.body;
 		const { debateName } = req.params;
 
 		const result = await dynamoDb.createDebateType({
 			specialUsers,
 			name: debateName,
 			description,
-			displayName
+			displayName,
+			createdAt,
+			createdBy
 		});
 		if (result.error) {
 			throw new Error(result.error);

--- a/routes/admin/main.js
+++ b/routes/admin/main.js
@@ -10,10 +10,8 @@ router.get('/', async (req, res) => {
 	const username = getS3oUsername(req.cookies);
 
 	try {
-		const debateList = await dynamoDb.getAllDebateLists();
 		res.render('admin/index', {
 			username,
-			debateList,
 			page: 'dashboard'
 		});
 	} catch (err) {

--- a/views/admin/editDebateType.hbs
+++ b/views/admin/editDebateType.hbs
@@ -30,7 +30,13 @@
 				<div class="o-forms">
 					<label for="createdBy" class="o-forms__label">Created By</label>
 					<input type="text" name="createdBy" class="o-forms__text" value="{{createdBy}}" required disabled />
-					<div id="msg_error" class="error o-forms__errortext hide" data-validation="createdBy"></div>
+					<input type="hidden" name="createdBy" class="o-forms__text" value="{{createdBy}}" required />
+				</div>
+				<div class="o-forms">
+					<label for="createdAt" class="o-forms__label">Created At</label>
+					<input type="text" name="createdAtFormated" class="o-forms__text" value="{{formatDate.readable}}"
+						disabled />
+					<input type="hidden" name="createdAt" class="o-forms__text" value="{{createdAt}}" required />
 				</div>
 				<div class="o-forms">
 					<label for="specialUsers" class="o-forms__label">Special user types</label>

--- a/views/admin/index.hbs
+++ b/views/admin/index.hbs
@@ -1,53 +1,13 @@
-{{> head title='Admin dashboard' subtitle='Admin section' }}
+{{> head title='Admin home' subtitle='Admin section' }}
 {{> admin/header }}
 <main class="o-grid-container">
-	<h1 class="admin-section">Dashboard</h1>
-	{{#if debateList}}
-	{{#each debateList}}
-	<div class="o-grid-row">
-		<section class="admin-content admin-debates-list">
-			<span class="debate-type-tag">Debate type</span>
-			<h2 class="debate-type">{{ debateTypeName }}</h2>
-			<table class="list-debates o-table  o-table--row-stripes" data-o-component="o-table">
-				<thead>
-					<tr>
-						<th scope="col" role="columnheader"> Name </th>
-						<th scope="col" role="columnheader"> Status </th>
-						<th scope="col" role="columnheader"> Voting </th>
-						<th scope="col" role="columnheader"> Creation date </th>
-					</tr>
-				</thead>
-				{{#if debates}}
-				<tbody>
-					{{#each debates}}
-					<tr>
-						<td>
-							{{ this.title }}
-						</td>
-						<td>
-							{{this.debateStatus}}
-						</td>
-						<td>
-							{{this.votingStatus}}
-						</td>
-						<td>
-							{{this.formatDate.readable}}
-						</td>
-						<td>
-							<a href="/{{ this.id }}">view</a>
-						</td>
-						<td>
-							<a href="/admin/debate/edit/{{ this.id }}">edit</a>
-						</td>
-					</tr>
-					{{/each}}
-				</tbody>
-				{{/if}}
-			</table>
-		</section>
-	</div>
-	{{/each}}
-	{{/if}}
+	<h1 class="admin-section">Home</h1>
+	<p>
+		Here in the admin section you can create/edit and list debates and debate types.
+	</p>
+	<p>
+		Please use the navigation to access the page(s) you need
+	</p>
 </main>
 
 {{> footer type="admin"}}

--- a/views/admin/listDebateTypes.hbs
+++ b/views/admin/listDebateTypes.hbs
@@ -32,7 +32,7 @@
 							{{this.createdBy}}
 						</td>
 						<td>
-							<a href="/admin/{{ this.name }}">view debates</a>
+							<a href="/admin/debate_type/list/{{ this.name }}">view debates</a>
 						</td>
 						<td>
 							<a href="/admin/debate_type/edit/{{ this.name }}">edit</a>

--- a/views/admin/listDebateTypes.hbs
+++ b/views/admin/listDebateTypes.hbs
@@ -1,0 +1,53 @@
+{{> head title='Debate Type Dashboard' subtitle='Admin section' }}
+{{> admin/header }}
+<main class="o-grid-container">
+	<h1 class="admin-section">Debate Type Dashboard</h1>
+	{{#if debateTypeList}}
+	{{#each debateTypeList}}
+	<div class="o-grid-row">
+		<section class="admin-content admin-debates-list">
+			<span class="debate-type-tag">Debate type</span>
+			<h2 class="debate-type">{{ debateTypeName }}</h2>
+			<table class="list-debates o-table  o-table--row-stripes" data-o-component="o-table">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader"> Name </th>
+						<th scope="col" role="columnheader"> Status </th>
+						<th scope="col" role="columnheader"> Voting </th>
+						<th scope="col" role="columnheader"> Creation date </th>
+					</tr>
+				</thead>
+				{{#if debates}}
+				<tbody>
+					{{#each debates}}
+					<tr>
+						<td>
+							{{ this.title }}
+						</td>
+						<td>
+							{{this.debateStatus}}
+						</td>
+						<td>
+							{{this.votingStatus}}
+						</td>
+						<td>
+							{{this.formatDate.readable}}
+						</td>
+						<td>
+							<a href="/{{ this.id }}">view</a>
+						</td>
+						<td>
+							<a href="/admin/debate/edit/{{ this.id }}">edit</a>
+						</td>
+					</tr>
+					{{/each}}
+				</tbody>
+				{{/if}}
+			</table>
+		</section>
+	</div>
+	{{/each}}
+	{{/if}}
+</main>
+
+{{> footer type="admin"}}

--- a/views/admin/listDebateTypes.hbs
+++ b/views/admin/listDebateTypes.hbs
@@ -2,8 +2,6 @@
 {{> admin/header }}
 <main class="o-grid-container">
 	<h1 class="admin-section">Debate Type Dashboard</h1>
-	{{#if debateTypeList}}
-	{{#each debateTypeList}}
 	<div class="o-grid-row">
 		<section class="admin-content admin-debates-list">
 			<span class="debate-type-tag">Debate type</span>
@@ -12,32 +10,32 @@
 				<thead>
 					<tr>
 						<th scope="col" role="columnheader"> Name </th>
-						<th scope="col" role="columnheader"> Status </th>
-						<th scope="col" role="columnheader"> Voting </th>
+						<th scope="col" role="columnheader"> Description </th>
 						<th scope="col" role="columnheader"> Creation date </th>
+						<th scope="col" role="columnheader"> Created By </th>
 					</tr>
 				</thead>
-				{{#if debates}}
+				{{#if debateTypeList}}
 				<tbody>
-					{{#each debates}}
+					{{#each debateTypeList}}
 					<tr>
 						<td>
-							{{ this.title }}
+							{{ this.displayName }}
 						</td>
 						<td>
-							{{this.debateStatus}}
-						</td>
-						<td>
-							{{this.votingStatus}}
+							{{this.description}}
 						</td>
 						<td>
 							{{this.formatDate.readable}}
 						</td>
 						<td>
-							<a href="/{{ this.id }}">view</a>
+							{{this.createdBy}}
 						</td>
 						<td>
-							<a href="/admin/debate/edit/{{ this.id }}">edit</a>
+							<a href="/admin/{{ this.name }}">view debates</a>
+						</td>
+						<td>
+							<a href="/admin/debate_type/edit/{{ this.name }}">edit</a>
 						</td>
 					</tr>
 					{{/each}}
@@ -46,8 +44,6 @@
 			</table>
 		</section>
 	</div>
-	{{/each}}
-	{{/if}}
 </main>
 
 {{> footer type="admin"}}

--- a/views/admin/listDebates.hbs
+++ b/views/admin/listDebates.hbs
@@ -1,0 +1,53 @@
+{{> head title='Debate dashboard' subtitle='Admin section' }}
+{{> admin/header }}
+<main class="o-grid-container">
+	<h1 class="admin-section">Debate Dashboard</h1>
+	{{#if debateList}}
+	{{#each debateList}}
+	<div class="o-grid-row">
+		<section class="admin-content admin-debates-list">
+			<span class="debate-type-tag">Debate type</span>
+			<h2 class="debate-type">{{ debateTypeName }}</h2>
+			<table class="list-debates o-table  o-table--row-stripes" data-o-component="o-table">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader"> Name </th>
+						<th scope="col" role="columnheader"> Status </th>
+						<th scope="col" role="columnheader"> Voting </th>
+						<th scope="col" role="columnheader"> Creation date </th>
+					</tr>
+				</thead>
+				{{#if debates}}
+				<tbody>
+					{{#each debates}}
+					<tr>
+						<td>
+							{{ this.title }}
+						</td>
+						<td>
+							{{this.debateStatus}}
+						</td>
+						<td>
+							{{this.votingStatus}}
+						</td>
+						<td>
+							{{this.formatDate.readable}}
+						</td>
+						<td>
+							<a href="/{{ this.id }}">view</a>
+						</td>
+						<td>
+							<a href="/admin/debate/edit/{{ this.id }}">edit</a>
+						</td>
+					</tr>
+					{{/each}}
+				</tbody>
+				{{/if}}
+			</table>
+		</section>
+	</div>
+	{{/each}}
+	{{/if}}
+</main>
+
+{{> footer type="admin"}}

--- a/views/admin/listDebatesByType.hbs
+++ b/views/admin/listDebatesByType.hbs
@@ -1,14 +1,11 @@
 {{> head title='Debate dashboard' subtitle='Admin section' }}
 {{> admin/header }}
 <main class="o-grid-container">
-	<h1 class="admin-section">Debate Dashboard</h1>
-	{{#if debateList}}
-	{{#each debateList}}
+	<h1 class="admin-section">Debate</h1>
 	<div class="o-grid-row">
 		<section class="admin-content admin-debates-list">
 			<span class="debate-type-tag">Debate type</span>
-			<h2 class="debate-type">
-				<a href="/admin/debate_type/list/{{ debateTypeName }}">{{ debateTypeName }}</a></h2>
+			<h2 class="debate-type">{{ debatesByType.debateTypeName }}</h2>
 			<table class="list-debates o-table  o-table--row-stripes" data-o-component="o-table">
 				<thead>
 					<tr>
@@ -18,9 +15,9 @@
 						<th scope="col" role="columnheader"> Creation date </th>
 					</tr>
 				</thead>
-				{{#if debates}}
+				{{#if debatesByType.debates}}
 				<tbody>
-					{{#each debates}}
+					{{#each debatesByType.debates}}
 					<tr>
 						<td>
 							{{ this.title }}
@@ -47,8 +44,6 @@
 			</table>
 		</section>
 	</div>
-	{{/each}}
-	{{/if}}
 </main>
 
 {{> footer type="admin"}}

--- a/views/partials/admin/header.hbs
+++ b/views/partials/admin/header.hbs
@@ -16,7 +16,7 @@
 				</li>
 				<li>
 					<a {{#ifEquals page "debateTypes"}} aria-current="true" {{/ifEquals}}
-						href="/admin/debateType/list">Debate type list</a>
+						href="/admin/debate_type/list">Debate type list</a>
 				</li>
 				<li>
 					<a {{#ifEquals page "create"}} aria-current="true" {{/ifEquals}} href="/admin/debate/create">Create

--- a/views/partials/admin/header.hbs
+++ b/views/partials/admin/header.hbs
@@ -2,17 +2,21 @@
 	{{> user/header username=username admin="admin"}}
 	<nav class="o-header-services__secondary-nav" aria-label="secondary" data-o-header-services-nav="">
 		<div class="o-header-services__secondary-nav-content" data-o-header-services-nav-list="">
-			<ol class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--ancestors"
-				aria-label="Ancestor sections">
+			<ol class="o-header-services__secondary-nav-list " aria-label="Ancestor sections">
 				<li>
-					<a href="">Admin</a>
+					<a href="/admin">Home</a>
 				</li>
 			</ol>
 
 			<ul class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--children"
 				aria-label="Child sections">
 				<li>
-					<a {{#ifEquals page "dashboard"}} aria-current="true" {{/ifEquals}} href="/admin">Dashboard</a>
+					<a {{#ifEquals page "debates"}} aria-current="true" {{/ifEquals}} href="/admin/debate/list">Debate
+						list</a>
+				</li>
+				<li>
+					<a {{#ifEquals page "debateTypes"}} aria-current="true" {{/ifEquals}}
+						href="/admin/debateType/list">Debate type list</a>
 				</li>
 				<li>
 					<a {{#ifEquals page "create"}} aria-current="true" {{/ifEquals}} href="/admin/debate/create">Create


### PR DESCRIPTION
## Description

Adds a list of all Debate types so that you can see all debates belonging to this type and find existing types to edit.

## Implementation

- Splits existing index page into a dashboard for debates and a placeholder homepage
- Adds new debate type listing page
- Adds new debates *by type* listing page

## Screenshot

n/a

## .env changes

n/a

## Additional requirements

n/a


![Whaaaaa](https://media.giphy.com/media/10CQOoOrvfpgbe/giphy.gif)
