### PR TITLE
[Feature] Adds display counter for upvotes + adds debate & debate type listing pages

### DIFF
--- a/helpers/comments.js
+++ b/helpers/comments.js
@@ -30,9 +30,6 @@ function getNestedComments(originParams) {
 	const commentsReplies = [];
 
 	params.commentsDataFiltered.forEach((comment) => {
-		//comment.upVotes = countUpVotes(comment);
-		//comment.upVoters = getUpVoters(comment);
-
 		const { upVotes, upVoters } = getUpVotes(comment);
 		comment.upVotes = upVotes;
 		comment.upVoters = upVoters;

--- a/helpers/comments.js
+++ b/helpers/comments.js
@@ -30,6 +30,8 @@ function getNestedComments(originParams) {
 	const commentsReplies = [];
 
 	params.commentsDataFiltered.forEach((comment) => {
+		comment.upVotes = countUpVotes(comment);
+
 		if (!Utils.hasOwnPropertyCall(comment, 'replyTo')) {
 			commentsOrigin.push(comment);
 		} else {
@@ -98,6 +100,18 @@ function getAndNestComments(comments) {
 		commentsFor,
 		commentsAgainst
 	};
+}
+
+function countUpVotes(comment) {
+	let upVotes = 0;
+	if (comment && comment.ratings) {
+		comment.ratings.forEach((rating) => {
+			if (rating.rating === 'upvote') {
+				upVotes = upVotes + 1;
+			}
+		});
+	}
+	return upVotes;
 }
 
 module.exports = {

--- a/helpers/comments.js
+++ b/helpers/comments.js
@@ -31,6 +31,7 @@ function getNestedComments(originParams) {
 
 	params.commentsDataFiltered.forEach((comment) => {
 		comment.upVotes = countUpVotes(comment);
+		comment.upVoters = getUpVoters(comment);
 
 		if (!Utils.hasOwnPropertyCall(comment, 'replyTo')) {
 			commentsOrigin.push(comment);
@@ -112,6 +113,18 @@ function countUpVotes(comment) {
 		});
 	}
 	return upVotes;
+}
+
+function getUpVoters(comment) {
+	let upVoters = [];
+	if (comment && comment.ratings) {
+		comment.ratings.forEach((rating) => {
+			if (rating.rating === 'upvote') {
+				upVoters.push(rating.user);
+			}
+		});
+	}
+	return upVoters;
 }
 
 module.exports = {

--- a/helpers/comments.js
+++ b/helpers/comments.js
@@ -30,8 +30,13 @@ function getNestedComments(originParams) {
 	const commentsReplies = [];
 
 	params.commentsDataFiltered.forEach((comment) => {
-		comment.upVotes = countUpVotes(comment);
-		comment.upVoters = getUpVoters(comment);
+		//comment.upVotes = countUpVotes(comment);
+		//comment.upVoters = getUpVoters(comment);
+
+		const { upVotes, upVoters } = getUpVotes(comment);
+		comment.upVotes = upVotes;
+		comment.upVoters = upVoters;
+
 		comment.usernameNice = Utils.cleanUsername(comment.user);
 		if (!Utils.hasOwnPropertyCall(comment, 'replyTo')) {
 			commentsOrigin.push(comment);
@@ -103,28 +108,18 @@ function getAndNestComments(comments) {
 	};
 }
 
-function countUpVotes(comment) {
+function getUpVotes(comment) {
 	let upVotes = 0;
-	if (comment && comment.ratings) {
-		comment.ratings.forEach((rating) => {
-			if (rating.rating === 'upvote') {
-				upVotes = upVotes + 1;
-			}
-		});
-	}
-	return upVotes;
-}
-
-function getUpVoters(comment) {
 	let upVoters = [];
 	if (comment && comment.ratings) {
 		comment.ratings.forEach((rating) => {
 			if (rating.rating === 'upvote') {
+				upVotes = upVotes + 1;
 				upVoters.push(rating.user);
 			}
 		});
 	}
-	return upVoters;
+	return { upVotes, upVoters };
 }
 
 module.exports = {

--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -53,9 +53,16 @@ function capitalize(str) {
 	});
 }
 
+function trimDescription(description, maxStrLength = 80) {
+	return description.length > maxStrLength
+		? description.substring(0, maxStrLength).trim() + '...'
+		: description;
+}
+
 module.exports = {
 	formatDate,
 	sortByDate,
 	hasOwnPropertyCall,
-	cleanUsername
+	cleanUsername,
+	trimDescription
 };

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ if (process.env.NODE_ENV === 'production') {
 	app.use(express_enforces_ssl());
 }
 
-app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
 
 app.engine(
 	'hbs',

--- a/models/dynamoDb.js
+++ b/models/dynamoDb.js
@@ -150,6 +150,9 @@ async function getAllDebateLists(type = 'nested') {
 			debates = [];
 			queryStatement.result['Items'].forEach((item) => {
 				item.formatDate = Utils.formatDate(item.createdAt);
+				item.descriptionTruncated = Utils.trimDescription(
+					item.description
+				);
 				debates.push(item);
 			});
 
@@ -163,7 +166,7 @@ async function getAllDebateLists(type = 'nested') {
 			debateTypes.forEach((type) => {
 				debateTypeDetails[type.name] = type.displayName;
 			});
-      
+
 			queryStatement.result['Items'].map((item) => {
 				if (!debates.hasOwnProperty(item.debateType)) {
 					debates[item.debateType] = {
@@ -173,7 +176,12 @@ async function getAllDebateLists(type = 'nested') {
 						debates: []
 					};
 				}
+
 				item.formatDate = Utils.formatDate(item.createdAt);
+				item.descriptionTruncated = Utils.trimDescription(
+					item.description
+				);
+
 				debates[item.debateType].debates.push(item);
 				Utils.sortByDate(debates[item.debateType].debates, 'createdAt');
 			});
@@ -253,9 +261,9 @@ function updateExpressionConstruct(data, replaceExisting = false) {
 		} else if (NESTED_LIST_TYPES.includes(key)) {
 			updateExpression += ` comments[${
 				data[key][0].index
-				}].${key}=list_append(comments[${
+			}].${key}=list_append(comments[${
 				data[key][0].index
-				}].${key}, :${key})`;
+			}].${key}, :${key})`;
 		} else {
 			updateExpression += ` ${key}=:${key}`;
 		}
@@ -399,6 +407,10 @@ async function getAllDebateTypes() {
 			let debateTypes = [];
 			queryStatement.result['Items'].forEach((item) => {
 				item.formatDate = Utils.formatDate(item.createdAt);
+				item.descriptionTruncated = Utils.trimDescription(
+					item.description,
+					150
+				);
 				debateTypes.push(item);
 			});
 			return debateTypes;

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -172,7 +172,6 @@ router.get('/list', async (req, res) => {
 	const username = getS3oUsername(req.cookies);
 	try {
 		const debateList = await dynamoDb.getAllDebateLists();
-		console.log(debateList);
 		res.render('admin/listDebates', {
 			username,
 			debateList,

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -11,7 +11,7 @@ router.get('/create', async (req, res) => {
 		const { alertType, alertAction } = req.query;
 
 		res.render('admin/createDebate', {
-			debateTypes: debateTypes.Items,
+			debateTypes: debateTypes,
 			username,
 			page: 'create',
 			alertMessage: getAlertMessage(

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -83,7 +83,7 @@ router.get('/edit/:debateTypeName', async (req, res) => {
 		const username = getS3oUsername(req.cookies);
 		const { debateTypeName } = req.params;
 		const debateType = await dynamoDb.getDebateType(debateTypeName);
-    
+
 		if (debateType.Items.length === 0) {
 			throw new Error('Cant find debate type');
 		}
@@ -135,8 +135,8 @@ router.get('/edit/:debateTypeName', async (req, res) => {
 router.post('/edit/:debateTypeName', async (req, res) => {
 	try {
 		const {
-      name,
-      tags,
+			name,
+			tags,
 			specialUsers,
 			description,
 			displayName,
@@ -147,7 +147,7 @@ router.post('/edit/:debateTypeName', async (req, res) => {
 
 		const result = await dynamoDb.createDebateType({
 			specialUsers,
-      tags,
+			tags,
 			name: debateTypeName,
 			description,
 			displayName,

--- a/routes/admin/main.js
+++ b/routes/admin/main.js
@@ -16,7 +16,6 @@ router.get('/', async (req, res) => {
 				username,
 				usernameNice: Utils.cleanUsername(username)
 			},
-			debateList,
 			page: 'dashboard'
 		});
 	} catch (err) {

--- a/routes/rating.js
+++ b/routes/rating.js
@@ -18,6 +18,7 @@ router.post('/:debateType/:debateId', async (req, res, next) => {
 				})
 			]
 		};
+
 		await customLogic({
 			functionName: 'post',
 			username: req.cookies.s3o_username,

--- a/routes/router.js
+++ b/routes/router.js
@@ -142,6 +142,7 @@ router.post('/:debateId', async (req, res, next) => {
 });
 
 router.use(function(err, req, res, next) {
+	const username = getS3oUsername(req.cookies);
 	console.log(err);
 	res.status(404);
 

--- a/sass/components/comments.scss
+++ b/sass/components/comments.scss
@@ -34,7 +34,26 @@
 	.o-replies,
 	.comment-actions {
 		grid-column-start: 1;
-		grid-column-end: 3;
+		grid-column-end: 2;
+	}
+
+	.comment-counter-upvotes {
+		text-align: right;
+
+		span {
+			margin: 0;
+			color: gray;
+			opacity: 0.8;
+			font-family: MetricWeb, sans-serif;
+			font-size: 12px;
+			line-height: 16px;
+			margin-bottom: 16px;
+			position: relative;
+			width: 100%;
+			text-decoration: none;
+			text-rendering: optimizeLegibility;
+			-webkit-font-smoothing: antialiased;
+		}
 	}
 
 	.comment-actions {

--- a/sass/components/comments.scss
+++ b/sass/components/comments.scss
@@ -31,10 +31,19 @@
 	}
 
 	.o-teaser__text,
-	.o-replies,
+	.o-replies {
+		grid-column-start: 1;
+		grid-column-end: 3;
+	}
+
 	.comment-actions {
 		grid-column-start: 1;
 		grid-column-end: 2;
+	}
+
+	.comment-counter-upvotes {
+		grid-column-start: 2;
+		grid-column-end: 3;
 	}
 
 	.comment-counter-upvotes {
@@ -42,7 +51,7 @@
 
 		span {
 			margin: 0;
-			color: gray;
+			color: $o-color-black-60;
 			opacity: 0.8;
 			font-family: MetricWeb, sans-serif;
 			font-size: 12px;
@@ -58,9 +67,20 @@
 
 	.comment-actions {
 		text-align: left;
+
+		margin: 0;
+		color: $o-color-black-60;
+		opacity: 0.8;
+		font-family: MetricWeb, sans-serif;
+		font-size: 12px;
+		line-height: 16px;
+		text-decoration: none;
+		text-rendering: optimizeLegibility;
+		-webkit-font-smoothing: antialiased;
+
 		a {
 			margin: 0;
-			color: gray;
+			color: $o-color-black-60;
 			opacity: 0.8;
 			font-family: MetricWeb, sans-serif;
 			font-size: 12px;
@@ -73,7 +93,9 @@
 			-webkit-font-smoothing: antialiased;
 
 			&:hover {
+				color: $o-color-black;
 				text-decoration: underline;
+				opacity: 1;
 			}
 		}
 	}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -283,7 +283,22 @@ h2.debate-type {
   .single-comment .o-replies,
   .single-comment .comment-actions {
     grid-column-start: 1;
-    grid-column-end: 3; }
+    grid-column-end: 2; }
+  .single-comment .comment-counter-upvotes {
+    text-align: right; }
+    .single-comment .comment-counter-upvotes span {
+      margin: 0;
+      color: gray;
+      opacity: 0.8;
+      font-family: MetricWeb, sans-serif;
+      font-size: 12px;
+      line-height: 16px;
+      margin-bottom: 16px;
+      position: relative;
+      width: 100%;
+      text-decoration: none;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased; }
   .single-comment .comment-actions {
     text-align: left; }
     .single-comment .comment-actions a {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -280,15 +280,20 @@ h2.debate-type {
   .single-comment .o-teaser__text {
     margin: 8px 0; }
   .single-comment .o-teaser__text,
-  .single-comment .o-replies,
+  .single-comment .o-replies {
+    grid-column-start: 1;
+    grid-column-end: 3; }
   .single-comment .comment-actions {
     grid-column-start: 1;
     grid-column-end: 2; }
   .single-comment .comment-counter-upvotes {
+    grid-column-start: 2;
+    grid-column-end: 3; }
+  .single-comment .comment-counter-upvotes {
     text-align: right; }
     .single-comment .comment-counter-upvotes span {
       margin: 0;
-      color: gray;
+      color: #666666;
       opacity: 0.8;
       font-family: MetricWeb, sans-serif;
       font-size: 12px;
@@ -300,10 +305,19 @@ h2.debate-type {
       text-rendering: optimizeLegibility;
       -webkit-font-smoothing: antialiased; }
   .single-comment .comment-actions {
-    text-align: left; }
+    text-align: left;
+    margin: 0;
+    color: #666666;
+    opacity: 0.8;
+    font-family: MetricWeb, sans-serif;
+    font-size: 12px;
+    line-height: 16px;
+    text-decoration: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased; }
     .single-comment .comment-actions a {
       margin: 0;
-      color: gray;
+      color: #666666;
       opacity: 0.8;
       font-family: MetricWeb, sans-serif;
       font-size: 12px;
@@ -315,7 +329,9 @@ h2.debate-type {
       text-rendering: optimizeLegibility;
       -webkit-font-smoothing: antialiased; }
       .single-comment .comment-actions a:hover {
-        text-decoration: underline; }
+        color: #000000;
+        text-decoration: underline;
+        opacity: 1; }
   .single-comment .o-replies {
     max-width: 100%;
     margin-top: 15px; }

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -68,7 +68,7 @@ function addRatingsEventListeners() {
 }
 
 function rateComment(debateId, debateType, index, rating) {
-	const data = {
+	var data = {
 		index: index,
 		rating: rating
 	};
@@ -89,7 +89,7 @@ function rateComment(debateId, debateType, index, rating) {
 }
 
 function removeRatingComment(debateId, index, username) {
-	const data = {
+	var data = {
 		index: index,
 		username: username
 	};

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -51,7 +51,6 @@ function addRatingsEventListeners() {
 				element.getAttribute('data-index'),
 				element.getAttribute('data-rating')
 			);
-			location.reload();
 		});
 	});
 
@@ -64,7 +63,6 @@ function addRatingsEventListeners() {
 				element.getAttribute('data-index'),
 				element.getAttribute('data-username')
 			);
-			location.reload();
 		});
 	});
 }
@@ -81,9 +79,13 @@ function rateComment(debateId, debateType, index, rating) {
 		headers: {
 			'Content-Type': 'application/json'
 		}
-	}).catch(function(res) {
-		console.log(res);
-	});
+	})
+		.then(function(res) {
+			location.reload();
+		})
+		.catch(function(res) {
+			console.log(res);
+		});
 }
 
 function removeRatingComment(debateId, index, username) {
@@ -98,9 +100,13 @@ function removeRatingComment(debateId, index, username) {
 		headers: {
 			'Content-Type': 'application/json'
 		}
-	}).catch(function(res) {
-		console.log(res);
-	});
+	})
+		.then(function(res) {
+			location.reload();
+		})
+		.catch(function(res) {
+			console.log(res);
+		});
 }
 
 function initComments() {

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -54,6 +54,19 @@ function addRatingsEventListeners() {
 			location.reload();
 		});
 	});
+
+	var ratingRemoveLinks = document.querySelectorAll('.rate-remove');
+
+	Array.from(ratingRemoveLinks).forEach(function(element) {
+		element.addEventListener('click', function(e) {
+			removeRatingComment(
+				element.getAttribute('data-debate-id'),
+				element.getAttribute('data-index'),
+				element.getAttribute('data-username')
+			);
+			location.reload();
+		});
+	});
 }
 
 function rateComment(debateId, debateType, index, rating) {
@@ -68,13 +81,26 @@ function rateComment(debateId, debateType, index, rating) {
 		headers: {
 			'Content-Type': 'application/json'
 		}
-	})
-		.then(function(res) {
-			console.log(res);
-		})
-		.catch(function(res) {
-			console.log(res);
-		});
+	}).catch(function(res) {
+		console.log(res);
+	});
+}
+
+function removeRatingComment(debateId, index, username) {
+	const data = {
+		index: index,
+		username: username
+	};
+
+	fetch(`rating/remove/${debateId}?`, {
+		method: 'POST',
+		body: JSON.stringify(data),
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	}).catch(function(res) {
+		console.log(res);
+	});
 }
 
 function initComments() {

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -51,6 +51,7 @@ function addRatingsEventListeners() {
 				element.getAttribute('data-index'),
 				element.getAttribute('data-rating')
 			);
+			location.reload();
 		});
 	});
 }

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -47,6 +47,7 @@ function addRatingsEventListeners() {
 		element.addEventListener('click', function(e) {
 			rateComment(
 				element.getAttribute('data-debate-id'),
+				element.getAttribute('data-debate-type'),
 				element.getAttribute('data-index'),
 				element.getAttribute('data-rating')
 			);
@@ -54,14 +55,18 @@ function addRatingsEventListeners() {
 	});
 }
 
-function rateComment(debateId, index, rating) {
-	var formData = new FormData();
-	formData.append('index', index);
-	formData.append('rating', rating);
+function rateComment(debateId, debateType, index, rating) {
+	const data = {
+		index: index,
+		rating: rating
+	};
 
-	fetch(`rating/${debateId}?`, {
+	fetch(`rating/${debateType}/${debateId}?`, {
 		method: 'POST',
-		body: formData
+		body: JSON.stringify(data),
+		headers: {
+			'Content-Type': 'application/json'
+		}
 	})
 		.then(function(res) {
 			console.log(res);
@@ -73,6 +78,7 @@ function rateComment(debateId, index, rating) {
 
 function initComments() {
 	addReplyEventListeners();
+	addRatingsEventListeners();
 	showVotes();
 }
 

--- a/utils/hbs-helpers.js
+++ b/utils/hbs-helpers.js
@@ -18,11 +18,16 @@ function ifInList(item, list, options) {
 	return list.includes(item) ? options.inverse(this) : options.fn(this);
 }
 
+function ifThisGreaterThanThat(varThis, varThat, options) {
+	return varThis > varThat ? options.inverse(this) : options.fn(this);
+}
+
 function registerHelpers(hbs) {
 	hbs.registerHelper('ifEquals', ifEquals);
 	hbs.registerHelper('ifThisOrThat', ifThisOrThat);
 	hbs.registerHelper('ifNotThisOrThat', ifNotThisOrThat);
 	hbs.registerHelper('ifInList', ifInList);
+	hbs.registerHelper('ifThisGreaterThanThat', ifThisGreaterThanThat);
 }
 
 module.exports = {

--- a/utils/hbs-helpers.js
+++ b/utils/hbs-helpers.js
@@ -14,10 +14,15 @@ function ifNotThisOrThat(arg1, arg2, options) {
 		: options.fn(this);
 }
 
+function ifInList(item, list, options) {
+	return list.includes(item) ? options.inverse(this) : options.fn(this);
+}
+
 function registerHelpers(hbs) {
 	hbs.registerHelper('ifEquals', ifEquals);
 	hbs.registerHelper('ifThisOrThat', ifThisOrThat);
 	hbs.registerHelper('ifNotThisOrThat', ifNotThisOrThat);
+	hbs.registerHelper('ifInList', ifInList);
 }
 
 module.exports = {

--- a/views/admin/listDebateTypes.hbs
+++ b/views/admin/listDebateTypes.hbs
@@ -23,7 +23,9 @@
 							{{ this.displayName }}
 						</td>
 						<td>
-							{{this.description}}
+							<p>
+								{{this.descriptionTruncated}}
+							</p>
 						</td>
 						<td>
 							{{this.formatDate.readable}}

--- a/views/debates/forAgainstWithVoting.hbs
+++ b/views/debates/forAgainstWithVoting.hbs
@@ -31,13 +31,13 @@
 			<div class="comments-for" data-o-grid-colspan="6">
 				<h2>For</h2>
 				{{#if commentsFor}}
-				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId debateType=debateType repliesOpen=debateOpen listStyleClass="forAgainstWithColour" }}
+				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId debateType=debateType repliesOpen=debateOpen listStyleClass="forAgainstWithColour" currentUser=user.username }}
 				{{/if}}
 			</div>
 			<div class="comments-against" data-o-grid-colspan="6">
 				<h2>Against</h2>
 				{{#if commentsAgainst}}
-				{{> components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId debateType=debateType repliesOpen=debateOpen listStyleClass="forAgainstWithColour" }}
+				{{> components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId debateType=debateType repliesOpen=debateOpen listStyleClass="forAgainstWithColour" currentUser=user.username }}
 				{{/if}}
 			</div>
 		</div>

--- a/views/debates/forAgainstWithVoting.hbs
+++ b/views/debates/forAgainstWithVoting.hbs
@@ -43,7 +43,7 @@
 		</div>
 	</main>
 	{{/ifThisOrThat}}
-	]
+
 	{{#if votingOpen}}
 	{{> components/voting/new debateId=debateId existingVote=existingVote voteOptions=voteOptions }}
 	{{/if}}

--- a/views/debates/forAgainstWithVoting.hbs
+++ b/views/debates/forAgainstWithVoting.hbs
@@ -31,13 +31,13 @@
 			<div class="comments-for" data-o-grid-colspan="6">
 				<h2>For</h2>
 				{{#if commentsFor}}
-				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId repliesOpen=debateOpen listStyleClass="forAgainstWithColour" }}
+				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId debateType=debateType repliesOpen=debateOpen listStyleClass="forAgainstWithColour" }}
 				{{/if}}
 			</div>
 			<div class="comments-against" data-o-grid-colspan="6">
 				<h2>Against</h2>
 				{{#if commentsAgainst}}
-				{{>  components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId  repliesOpen=debateOpen listStyleClass="forAgainstWithColour" }}
+				{{> components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId debateType=debateType repliesOpen=debateOpen listStyleClass="forAgainstWithColour" }}
 				{{/if}}
 			</div>
 		</div>

--- a/views/debates/foragainst.hbs
+++ b/views/debates/foragainst.hbs
@@ -31,13 +31,13 @@
 			<div class="comments-for" data-o-grid-colspan="6">
 				<h2>For</h2>
 				{{#if commentsFor}}
-				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId debateType=debateType repliesOpen=false }}
+				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId debateType=debateType repliesOpen=false currentUser=user.username }}
 				{{/if}}
 			</div>
 			<div class="comments-against" data-o-grid-colspan="6">
 				<h2>Against</h2>
 				{{#if commentsAgainst}}
-				{{>  components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId debateType=debateType repliesOpen=false }}
+				{{>  components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId debateType=debateType repliesOpen=false currentUser=user.username }}
 				{{/if}}
 			</div>
 		</div>

--- a/views/debates/foragainst.hbs
+++ b/views/debates/foragainst.hbs
@@ -31,13 +31,13 @@
 			<div class="comments-for" data-o-grid-colspan="6">
 				<h2>For</h2>
 				{{#if commentsFor}}
-				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId repliesOpen=false }}
+				{{> components/comments/list class='comments_list' comments=commentsFor debateId=debateId debateType=debateType repliesOpen=false }}
 				{{/if}}
 			</div>
 			<div class="comments-against" data-o-grid-colspan="6">
 				<h2>Against</h2>
 				{{#if commentsAgainst}}
-				{{>  components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId  repliesOpen=false }}
+				{{>  components/comments/list class='comments_list' comments=commentsAgainst debateId=debateId debateType=debateType repliesOpen=false }}
 				{{/if}}
 			</div>
 		</div>

--- a/views/list.hbs
+++ b/views/list.hbs
@@ -25,7 +25,7 @@
 						<a href="/{{this.id}}">{{ this.title }}</a>
 					</h2>
 
-					<p class="o-teaser__standfirst">{{this.description}}</p>
+					<p class="o-teaser__standfirst">{{this.descriptionTruncated}}</p>
 
 					<div class="o-teaser__timestamp"><time datetime="{{this.formatDate.datetime}}"
 							class="o-date o-teaser__timestamp">{{this.formatDate.readable}}</time></div>

--- a/views/partials/components/comments/list.hbs
+++ b/views/partials/components/comments/list.hbs
@@ -1,5 +1,5 @@
 {{#each comments}}
 <div class="comments-{{../listStyleClass}}">
-	{{> components/comments/single class=this.tags comment=this debateId=../debateId repliesOpen=../repliesOpen listStyleClass=../listStyleClass }}
+	{{> components/comments/single class=this.tags comment=this debateId=../debateId debateType=../debateType repliesOpen=../repliesOpen listStyleClass=../listStyleClass }}
 </div>
 {{/each}}

--- a/views/partials/components/comments/list.hbs
+++ b/views/partials/components/comments/list.hbs
@@ -1,5 +1,5 @@
 {{#each comments}}
 <div class="comments-{{../listStyleClass}}">
-	{{> components/comments/single class=this.tags comment=this debateId=../debateId debateType=../debateType repliesOpen=../repliesOpen listStyleClass=../listStyleClass }}
+	{{> components/comments/single class=this.tags comment=this debateId=../debateId debateType=../debateType repliesOpen=../repliesOpen listStyleClass=../listStyleClass currentUser=../currentUser }}
 </div>
 {{/each}}

--- a/views/partials/components/comments/single.hbs
+++ b/views/partials/components/comments/single.hbs
@@ -5,8 +5,15 @@
 	<div class="comment-actions">
 		{{#if repliesOpen}}
 		<a data-comment-id="{{comment.id}}" class="reply" href="#">Reply</a>
+		|
+		{{#ifInList currentUser upVoters}}
 		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
 			class="rate" href="#">UpVote</a>
+		{{else}}
+		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
+			class="rate-remove" href="#">Remove UpVote</a>
+		{{/ifInList}}
+		|
 		{{/if}}
 		<a data-comment-id="{{comment.id}}" class="report" href="#">Report</a>
 	</div>

--- a/views/partials/components/comments/single.hbs
+++ b/views/partials/components/comments/single.hbs
@@ -5,10 +5,17 @@
 	<div class="comment-actions">
 		{{#if repliesOpen}}
 		<a data-comment-id="{{comment.id}}" class="reply" href="#">Reply</a>
-		<a data-debate-id="{{debateId}}" data-index="{{index}}" data-rating="upvote" class="rate" href="#">UpVote</a>
+		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
+			class="rate" href="#">UpVote</a>
 		{{/if}}
 		<a data-comment-id="{{comment.id}}" class="report" href="#">Report</a>
 	</div>
+
+	{{#if upVotes}}
+	<div class="comment-counter-upvotes">
+		<span>{{upVotes}} Upvotes</span>
+	</div>
+	{{/if}}
 
 	{{#if this.replies}}
 	<div class="o-replies">

--- a/views/partials/components/comments/single.hbs
+++ b/views/partials/components/comments/single.hbs
@@ -10,8 +10,8 @@
 		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
 			class="rate" href="#">UpVote</a>
 		{{else}}
-		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
-			class="rate-remove" href="#">Remove UpVote</a>
+		<a data-debate-id="{{debateId}}" data-index="{{index}}" data-username={{currentUser}} class="rate-remove"
+			href="#">Remove UpVote</a>
 		{{/ifInList}}
 		|
 		{{/if}}

--- a/views/partials/components/comments/single.hbs
+++ b/views/partials/components/comments/single.hbs
@@ -8,7 +8,7 @@
 		|
 		{{#ifInList currentUser upVoters}}
 		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
-			class="rate" href="#">UpVote</a>
+			class="rate" href="#">Up Vote</a>
 		{{else}}
 		<a data-debate-id="{{debateId}}" data-index="{{index}}" data-username={{currentUser}} class="rate-remove"
 			href="#">Remove UpVote</a>
@@ -20,7 +20,11 @@
 
 	{{#if upVotes}}
 	<div class="comment-counter-upvotes">
+		{{#ifThisGreaterThanThat upVotes 1}}
+		<span>{{upVotes}} Upvote</span>
+		{{else}}
 		<span>{{upVotes}} Upvotes</span>
+		{{/ifThisGreaterThanThat}}
 	</div>
 	{{/if}}
 


### PR DESCRIPTION
## Description

The up vote mechanic already existed, this adds a viewable counter for up votes as well as the ability to remove your vote.
Updates were also made to the listing pages for debates and debate types, to improve the admins ability to navigate to existing content and edit pages.

## Implementation

- adds up vote numbers to comments display
- adds feature to track if current user is one of the up voters
- adds feature for users to remove their up vote
- adds to the 'updateExpressionConstruct' to allow for a field content over write as well as an addition (otherwise comments were being duplicated)
- updates naming of path param in debate type to _debateTypeName_ from _debateName_
- adds handlebars helpers to help with content display on pages
- adds listing pages for debates and debate types

## Screenshot

![Screenshot 2019-06-03 at 10 19 19](https://user-images.githubusercontent.com/1937725/58790852-12280e80-85e9-11e9-9c54-4642f888f99c.png)

## .env changes

n/a

## Additional requirements

n/a

![Vote](https://media.giphy.com/media/3o6ozAxsUHHV2Kmy7m/giphy.gif)
