### PR TITLE
[Feature] File check for debate type files needed for debate instance.

### DIFF
--- a/models/dynamoDb.js
+++ b/models/dynamoDb.js
@@ -38,7 +38,7 @@ async function createDebate(data) {
 			Item: {
 				...data,
 				id,
-				comments: [],
+				comments: {},
 				createdAt,
 				updatedAt
 			}
@@ -239,9 +239,9 @@ function updateExpressionConstruct(data) {
 		} else if (NESTED_LIST_TYPES.includes(key)) {
 			updateExpression += ` comments[${
 				data[key][0].index
-				}].${key}=list_append(comments[${
+			}].${key}=list_append(comments[${
 				data[key][0].index
-				}].${key}, :${key})`;
+			}].${key}, :${key})`;
 		} else {
 			updateExpression += ` ${key}=:${key}`;
 		}

--- a/models/dynamoDb.js
+++ b/models/dynamoDb.js
@@ -38,7 +38,7 @@ async function createDebate(data) {
 			Item: {
 				...data,
 				id,
-				comments: {},
+				comments: [],
 				createdAt,
 				updatedAt
 			}

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -9,12 +9,8 @@ const Utils = require('../../helpers/utils');
 router.get('/create', async (req, res) => {
 	try {
 		const username = getS3oUsername(req.cookies);
-		let debateTypes = await dynamoDb.getAllDebateTypes();
+		const debateTypes = await dynamoDb.getAllDebateTypes();
 		const { alertType, alertAction } = req.query;
-		debateTypes = debateTypes.Items.map((debateType) => ({
-			...debateType,
-			valid: validateDebateTypeFile(debateType.name)
-		}));
 		res.render('admin/createDebate', {
 			debateTypes: debateTypes.Items,
 			user: {
@@ -206,22 +202,6 @@ router.get('/list', async (req, res) => {
 		res.status(404).send("Sorry can't find that!");
 	}
 });
-
-function validateDebateTypeFile(debateTypeName) {
-	try {
-		const filePath = path.resolve(
-			`./modules/${debateTypeName.toLowerCase()}.js`
-		);
-		if (fs.existsSync(filePath)) {
-			return true;
-		} else {
-			return false;
-		}
-	} catch (err) {
-		console.error(err);
-		return false;
-	}
-}
 
 function formatSpecialUsers(specialUsers) {
 	let specialUsersFormatted = [];

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -1,5 +1,6 @@
 const express = require('express');
-
+const fs = require('fs');
+const path = require('path');
 const router = express.Router();
 const dynamoDb = require('../../models/dynamoDb');
 const { getS3oUsername } = require('../../helpers/cookies');
@@ -7,11 +8,14 @@ const { getS3oUsername } = require('../../helpers/cookies');
 router.get('/create', async (req, res) => {
 	try {
 		const username = getS3oUsername(req.cookies);
-		const debateTypes = await dynamoDb.getAllDebateTypes();
+		let debateTypes = await dynamoDb.getAllDebateTypes();
 		const { alertType, alertAction } = req.query;
-
+		debateTypes = debateTypes.Items.map((debateType) => ({
+			...debateType,
+			valid: validateDebateTypeFile(debateType.name)
+		}));
 		res.render('admin/createDebate', {
-			debateTypes: debateTypes.Items,
+			debateTypes,
 			username,
 			page: 'create',
 			alertMessage: getAlertMessage(
@@ -185,6 +189,22 @@ router.post('/edit/:debateId', async (req, res) => {
 		);
 	}
 });
+
+function validateDebateTypeFile(debateTypeName) {
+	try {
+		const filePath = path.resolve(
+			`./modules/${debateTypeName.toLowerCase()}.js`
+		);
+		if (fs.existsSync(filePath)) {
+			return true;
+		} else {
+			return false;
+		}
+	} catch (err) {
+		console.error(err);
+		return false;
+	}
+}
 
 function formatSpecialUsers(specialUsers) {
 	let specialUsersFormatted = [];

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -9,10 +9,14 @@ const Utils = require('../../helpers/utils');
 router.get('/create', async (req, res) => {
 	try {
 		const username = getS3oUsername(req.cookies);
-		const debateTypes = await dynamoDb.getAllDebateTypes();
+		let debateTypes = await dynamoDb.getAllDebateTypes();
 		const { alertType, alertAction } = req.query;
+		debateTypes = debateTypes.map((debateType) => ({
+			...debateType,
+			valid: validateDebateTypeFile(debateType.name)
+		}));
 		res.render('admin/createDebate', {
-			debateTypes: debateTypes.Items,
+			debateTypes,
 			user: {
 				username,
 				usernameNice: Utils.cleanUsername(username)
@@ -202,6 +206,22 @@ router.get('/list', async (req, res) => {
 		res.status(404).send("Sorry can't find that!");
 	}
 });
+
+function validateDebateTypeFile(debateTypeName) {
+	try {
+		const filePath = path.resolve(
+			`./modules/${debateTypeName.toLowerCase()}.js`
+		);
+		if (fs.existsSync(filePath)) {
+			return true;
+		} else {
+			return false;
+		}
+	} catch (err) {
+		console.error(err);
+		return false;
+	}
+}
 
 function formatSpecialUsers(specialUsers) {
 	let specialUsersFormatted = [];

--- a/routes/admin/debateType.js
+++ b/routes/admin/debateType.js
@@ -1,5 +1,4 @@
 const express = require('express');
-
 const router = express.Router();
 const dynamoDb = require('../../models/dynamoDb');
 const { getS3oUsername } = require('../../helpers/cookies');

--- a/static/js/admin/debateForm.js
+++ b/static/js/admin/debateForm.js
@@ -92,15 +92,19 @@ function addDebateTypeSelectListener() {
 }
 
 function checkDebateTypeError(valid) {
-	console.log(valid);
-	const debateError = document.querySelector('.valid-debate-type-error');
-	console.log(debateError);
-	if (!Array.from(debateError.classList).includes('hide')) {
-		debateError.classList.add('hide');
+	const debateTypeError = document.querySelector('.valid-debate-type-error');
+	const debateErrorMessage = document.querySelector(
+		'.valid-debate-type-error-message'
+	);
+
+	if (!Array.from(debateTypeError.classList).includes('hide')) {
+		debateTypeError.classList.add('hide');
+		debateErrorMessage.innerHTML = '';
 	}
 	if (valid === 'false') {
-		console.log('gettng in if');
-		debateError.classList.remove('hide');
+		debateErrorMessage.innerHTML =
+			'The files for your selected debate type dont exist yet. Please refer to the project documentation for steps to do this.';
+		debateTypeError.classList.remove('hide');
 	}
 }
 

--- a/static/js/admin/debateForm.js
+++ b/static/js/admin/debateForm.js
@@ -76,10 +76,7 @@ function addDebateTypeSelectListener() {
 			var description = this.options[this.selectedIndex].getAttribute(
 				'data-description'
 			);
-			const name = this.options[this.selectedIndex].getAttribute(
-				'data-name'
-			);
-			const valid = this.options[this.selectedIndex].getAttribute(
+			var valid = this.options[this.selectedIndex].getAttribute(
 				'data-valid'
 			);
 
@@ -105,7 +102,7 @@ function checkDebateTypeError(valid) {
 	}
 	if (valid === 'false') {
 		debateErrorMessage.innerHTML =
-			'The files for your selected debate type dont exist yet. Please refer to the project documentation for steps to add them.';
+			"The files for your selected debate type don't exist yet. Please refer to the project documentation for steps to add them.";
 		debateTypeError.classList.remove('hide');
 	}
 }

--- a/static/js/admin/debateForm.js
+++ b/static/js/admin/debateForm.js
@@ -6,7 +6,7 @@ function addAdditionalTextFieldsListeners(
 	const addTextButtons = document.querySelectorAll(
 		'.' + action + '-text-field'
 	);
-	Array.from(addTextButtons).forEach(function (element) {
+	Array.from(addTextButtons).forEach(function(element) {
 		const attributeName = `specialUsers[${element.parentElement.parentElement.getAttribute(
 			'data-special-user-type'
 		)}]`;
@@ -25,7 +25,7 @@ function addEventListenerPlusAndMinus(
 	appendFunction,
 	attributeName
 ) {
-	element.addEventListener('click', function () {
+	element.addEventListener('click', function() {
 		const userInputs = Array.from(
 			element.parentElement.parentElement.childNodes
 		).find((element) =>
@@ -69,41 +69,52 @@ function addDebateTypeSelectListener() {
 	const tagsParentDiv = document.querySelector('.tags');
 
 	if (debateTypeSelector) {
-		debateTypeSelector.addEventListener('change', function (e) {
+		debateTypeSelector.addEventListener('change', function(e) {
 			const displayName = this.value;
 			const description = this.options[this.selectedIndex].getAttribute(
 				'data-description'
 			);
+			const name = this.options[this.selectedIndex].getAttribute(
+				'data-name'
+			);
+			const valid = this.options[this.selectedIndex].getAttribute(
+				'data-valid'
+			);
 
-			addSpecialUserElements(this, specialUsersParentDiv)
-			addTagsElements(this, tagsParentDiv)
+			checkDebateTypeError(valid);
+
+			addSpecialUserElements(this, specialUsersParentDiv);
+			addTagsElements(this, tagsParentDiv);
 
 			updateDescription(description);
 		});
 	}
 }
 
+function checkDebateTypeError(valid) {
+	console.log(valid);
+	const debateError = document.querySelector('.valid-debate-type-error');
+	console.log(debateError);
+	if (!Array.from(debateError.classList).includes('hide')) {
+		debateError.classList.add('hide');
+	}
+	if (valid === 'false') {
+		console.log('gettng in if');
+		debateError.classList.remove('hide');
+	}
+}
+
 function addTagsElements(element, tagsParentDiv) {
-	const tagsDescription = getDebateTypeValues(
-		element,
-		'tags-description'
-	);
-	const tagsName = getDebateTypeValues(
-		element,
-		'tags-name'
-	);
+	const tagsDescription = getDebateTypeValues(element, 'tags-description');
+	const tagsName = getDebateTypeValues(element, 'tags-name');
 	const tags = tagsName.map((name, index) => ({
 		name,
 		description: tagsDescription[index]
 	}));
 	while (tagsParentDiv.firstChild) {
-		tagsParentDiv.removeChild(
-			tagsParentDiv.firstChild
-		);
+		tagsParentDiv.removeChild(tagsParentDiv.firstChild);
 	}
-	tags.forEach((tag) =>
-		insertTags({ tagsParentDiv, ...tag })
-	);
+	tags.forEach((tag) => insertTags({ tagsParentDiv, ...tag }));
 }
 
 function addSpecialUserElements(element, specialUsersParentDiv) {
@@ -111,19 +122,14 @@ function addSpecialUserElements(element, specialUsersParentDiv) {
 		element,
 		'special-user-description'
 	);
-	const specialUserName = getDebateTypeValues(
-		element,
-		'special-user-name'
-	);
+	const specialUserName = getDebateTypeValues(element, 'special-user-name');
 
 	const specialUsers = specialUserName.map((name, index) => ({
 		name,
 		description: specialUserDescription[index]
 	}));
 	while (specialUsersParentDiv.firstChild) {
-		specialUsersParentDiv.removeChild(
-			specialUsersParentDiv.firstChild
-		);
+		specialUsersParentDiv.removeChild(specialUsersParentDiv.firstChild);
 	}
 	specialUsers.forEach((specialUser) =>
 		insertSpecialUser({ specialUsersParentDiv, ...specialUser })
@@ -190,7 +196,7 @@ function insertTags({ tagsParentDiv, name, description }) {
 	const span = document.createElement('span');
 	span.setAttribute('class', 'o-forms-input__label');
 	span.setAttribute('aria-hidden', 'true');
-	span.innerHTML = description
+	span.innerHTML = description;
 	checkLabel.appendChild(span);
 }
 

--- a/static/js/admin/debateForm.js
+++ b/static/js/admin/debateForm.js
@@ -103,7 +103,7 @@ function checkDebateTypeError(valid) {
 	}
 	if (valid === 'false') {
 		debateErrorMessage.innerHTML =
-			'The files for your selected debate type dont exist yet. Please refer to the project documentation for steps to do this.';
+			'The files for your selected debate type dont exist yet. Please refer to the project documentation for steps to add them.';
 		debateTypeError.classList.remove('hide');
 	}
 }

--- a/static/js/admin/debateForm.js
+++ b/static/js/admin/debateForm.js
@@ -94,8 +94,8 @@ function addDebateTypeSelectListener() {
 }
 
 function checkDebateTypeError(valid) {
-	const debateTypeError = document.querySelector('.valid-debate-type-error');
-	const debateErrorMessage = document.querySelector(
+	var debateTypeError = document.querySelector('.valid-debate-type-error');
+	var debateErrorMessage = document.querySelector(
 		'.valid-debate-type-error-message'
 	);
 

--- a/views/admin/createDebate.hbs
+++ b/views/admin/createDebate.hbs
@@ -27,8 +27,7 @@
 						data-o-component="o-message">
 						<div class="o-message__container">
 							<div class="o-message__content ">
-								<p class="o-message__content-main">
-									The files for your selected debate type dont exist yet. Please |action|
+								<p class="valid-debate-type-error-message o-message__content-main">
 								</p>
 							</div>
 						</div>

--- a/views/admin/createDebate.hbs
+++ b/views/admin/createDebate.hbs
@@ -32,7 +32,6 @@
 							</div>
 						</div>
 					</div>
-					<div id="msg_error" class="error o-forms__errortext hide" data-validation="debateType"></div>
 				</div>
 				<div class="o-forms">
 					<label for="title" class="o-forms__label">Title</label>

--- a/views/admin/createDebate.hbs
+++ b/views/admin/createDebate.hbs
@@ -17,7 +17,8 @@
 							data-special-user-name="{{#each specialUsers}}{{name}},{{/each}}"
 							data-tags-name="{{#each tags}}{{name}},{{/each}}"
 							data-tags-description="{{#each tags}}{{description}},{{/each}}"
-							data-description="{{description}}" data-name="{{name}}" value="{{name}}">
+							data-description="{{description}}" data-name="{{name}}" value="{{name}}"
+							data-valid="{{valid}}">
 							{{displayName}}
 						</option>
 						{{/each}}

--- a/views/admin/createDebate.hbs
+++ b/views/admin/createDebate.hbs
@@ -17,8 +17,7 @@
 							data-special-user-name="{{#each specialUsers}}{{name}},{{/each}}"
 							data-tags-name="{{#each tags}}{{name}},{{/each}}"
 							data-tags-description="{{#each tags}}{{description}},{{/each}}"
-							data-description="{{description}}" data-name="{{name}}" value="{{name}}"
-							data-valid="{{valid}}">
+							data-description="{{description}}" data-name="{{name}}" value="{{name}}">
 							{{displayName}}
 						</option>
 						{{/each}}

--- a/views/admin/createDebate.hbs
+++ b/views/admin/createDebate.hbs
@@ -6,8 +6,8 @@
 	<h1 class="admin-section">Create debate</h1>
 	<div class="o-grid-row">
 		<section class="admin-content">
-
 			<form id="form_new_debate" action="/admin/debate/create" method="POST" data-o-grid-colspan="6">
+
 				<div class="o-forms">
 					<label for="debateType" class="o-forms__label">Debate type</label>
 					<select name="debateType" class="debate-type o-forms__select" required>
@@ -17,11 +17,22 @@
 							data-special-user-name="{{#each specialUsers}}{{name}},{{/each}}"
 							data-tags-name="{{#each tags}}{{name}},{{/each}}"
 							data-tags-description="{{#each tags}}{{description}},{{/each}}"
-							data-description="{{description}}" data-name="{{name}}" value="{{name}}">
+							data-description="{{description}}" data-name="{{name}}" value="{{name}}"
+							data-valid="{{valid}}">
 							{{displayName}}
 						</option>
 						{{/each}}
 					</select>
+					<div class="valid-debate-type-error o-message o-message--alert  o-message--error hide"
+						data-o-component="o-message">
+						<div class="o-message__container">
+							<div class="o-message__content ">
+								<p class="o-message__content-main">
+									The files for your selected debate type dont exist yet. Please |action|
+								</p>
+							</div>
+						</div>
+					</div>
 					<div id="msg_error" class="error o-forms__errortext hide" data-validation="debateType"></div>
 				</div>
 				<div class="o-forms">


### PR DESCRIPTION
## Description

This pull request implements an immediate error when you select a debate type that does not have the needed files to work. It displays under the box and asks the user to refer to the documentation on how to set it up the required files (coming in a pull request in my list today). Not sure if this is the best action to recommend when seeing this error so let me know if you think it should be recommend something else?
