### PR TITLE
[Fix] Fix error messaging for debate and debate types.

### DIFF
--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -240,9 +240,9 @@ function formatSpecialUsers(specialUsers) {
 function getAlertMessage(alertType, action) {
 	switch (alertType) {
 		case 'success':
-			return `${action} your debate type was succesful.`;
+			return `${action} your debate was succesful.`;
 		case 'error':
-			return `Something went wrong ${action} your debate type.`;
+			return `Something went wrong ${action} your debate.`;
 		default:
 			return undefined;
 	}


### PR DESCRIPTION
## Description
It was saying debate type on the debate create form. Just changing copy.
