### PR TITLE
[Fix] Change DB structure so we can look up items easier.

### DIFF
--- a/helpers/comments.js
+++ b/helpers/comments.js
@@ -25,7 +25,7 @@ function getNestedComments(originParams, username) {
 		filterTag: null
 	};
 	const params = Object.assign(defaultParams, originParams);
-	const commentsNested = [];
+	let commentsNested = [];
 	const commentsOrigin = [];
 	const commentsReplies = [];
 
@@ -53,8 +53,13 @@ function getNestedComments(originParams, username) {
 			newComment,
 			params.commentsDataRaw
 		);
+
+		newComment.replies = Utils.sortByDate(newComment.replies, 'createdAt');
+
 		commentsNested.push(newComment);
 	});
+
+	commentsNested = Utils.sortByDate(commentsNested, 'createdAt');
 
 	if (
 		params.paginationStart !== null ||

--- a/modules/foragainstwithvoting.js
+++ b/modules/foragainstwithvoting.js
@@ -15,8 +15,10 @@ function display(req, res, data) {
 	} = debate;
 
 	const { commentsFor, commentsAgainst } = commentHelper.getAndNestComments(
-		comments
+		comments,
+		user.username
 	);
+
 	const debateOpen = debateStatus === 'open' ? true : false;
 	const votingOpen = votingStatus === 'open' ? true : false;
 	const voteOptions = ['for', 'against'];
@@ -25,6 +27,7 @@ function display(req, res, data) {
 		voteOptions
 	);
 	const existingVote = votesHelper.hasVoted(voteFromRatings, user.username);
+
 	const voteResults = votesHelper.calculateResults(
 		voteFromRatings,
 		voteOptions

--- a/routes/admin/debate.js
+++ b/routes/admin/debate.js
@@ -176,7 +176,7 @@ router.post('/edit/:debateId', async (req, res) => {
 			debateStatus,
 			votingStatus,
 			specialUsers: specialUsersFormatted,
-			tags
+			tags: tags ? tags : []
 		};
 		await dynamoDb.updateDebate(debateId, params);
 		res.redirect(

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -9,16 +9,15 @@ router.post('/:debateType/:debateId', async (req, res, next) => {
 		const backURL = req.header('Referer') || '/';
 		const { debateId, debateType } = req.params;
 		const { comment, tags, displayStatus, replyTo } = req.body;
+		console.log('req.body', req.body);
 		const data = {
-			comments: [
-				dynamoDb.constructCommentObject({
-					content: comment,
-					user: req.cookies.s3o_username,
-					tags,
-					replyTo,
-					displayStatus
-				})
-			]
+			comments: dynamoDb.constructCommentObject({
+				content: comment,
+				user: req.cookies.s3o_username,
+				tags,
+				replyTo,
+				displayStatus
+			})
 		};
 		await customLogic({ functionName: 'post', debateType });
 		await dynamoDb.updateDebate(debateId, data);

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -9,7 +9,6 @@ router.post('/:debateType/:debateId', async (req, res, next) => {
 		const backURL = req.header('Referer') || '/';
 		const { debateId, debateType } = req.params;
 		const { comment, tags, displayStatus, replyTo } = req.body;
-		console.log('req.body', req.body);
 		const data = {
 			comments: dynamoDb.constructCommentObject({
 				content: comment,

--- a/static/js/admin/debateTypeForm.js
+++ b/static/js/admin/debateTypeForm.js
@@ -124,11 +124,11 @@ function saveCustomTextField(textField, saveButton, editButton, userInputs) {
 
 function createNewFieldForm(attributeName, userInputs) {
 	var index =
-		Array.from(userInputs.parentElement.childNodes).filter(function(
-			element
-		) {
-			return element.nodeName === 'DIV';
-		}).length - 1;
+		Array.from(userInputs.parentElement.parentElement.childNodes).filter(
+			function(element) {
+				return element.nodeName === 'DIV';
+			}
+		).length - 1;
 
 	addLabelToField(
 		userInputs,
@@ -158,7 +158,7 @@ function createNewTagFormItem(attributeName, userInputs) {
 		Array.from(userInputs.parentElement.childNodes).filter(function(
 			element
 		) {
-			element.nodeName === 'DIV';
+			return element.nodeName === 'DIV';
 		}).length - 1;
 
 	addLabelToField(

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -41,6 +41,7 @@ function addReplyEventListeners() {
 }
 
 function addRatingsEventListeners() {
+	console;
 	var ratingLinks = document.querySelectorAll('.rate');
 
 	Array.from(ratingLinks).forEach(function(element) {
@@ -48,7 +49,7 @@ function addRatingsEventListeners() {
 			rateComment(
 				element.getAttribute('data-debate-id'),
 				element.getAttribute('data-debate-type'),
-				element.getAttribute('data-index'),
+				element.getAttribute('data-comment-id'),
 				element.getAttribute('data-rating')
 			);
 		});
@@ -60,19 +61,19 @@ function addRatingsEventListeners() {
 		element.addEventListener('click', function(e) {
 			removeRatingComment(
 				element.getAttribute('data-debate-id'),
-				element.getAttribute('data-index'),
-				element.getAttribute('data-username')
+				element.getAttribute('data-comment-id'),
+				element.getAttribute('data-username'),
+				element.getAttribute('data-rating-id')
 			);
 		});
 	});
 }
 
-function rateComment(debateId, debateType, index, rating) {
+function rateComment(debateId, debateType, commentId, rating) {
 	var data = {
-		index: index,
+		commentId: commentId,
 		rating: rating
 	};
-
 	fetch(`rating/${debateType}/${debateId}?`, {
 		method: 'POST',
 		body: JSON.stringify(data),
@@ -88,10 +89,11 @@ function rateComment(debateId, debateType, index, rating) {
 		});
 }
 
-function removeRatingComment(debateId, index, username) {
+function removeRatingComment(debateId, commentId, username, ratingId) {
 	var data = {
-		index: index,
-		username: username
+		commentId: commentId,
+		username: username,
+		ratingId: ratingId
 	};
 
 	fetch(`rating/remove/${debateId}?`, {

--- a/static/js/components/comments.js
+++ b/static/js/components/comments.js
@@ -41,7 +41,6 @@ function addReplyEventListeners() {
 }
 
 function addRatingsEventListeners() {
-	console;
 	var ratingLinks = document.querySelectorAll('.rate');
 
 	Array.from(ratingLinks).forEach(function(element) {

--- a/static/js/components/reports.js
+++ b/static/js/components/reports.js
@@ -1,0 +1,17 @@
+/* eslint-env browser */
+
+function addRatingsEventListeners() {
+	var ratingLinks = document.querySelectorAll('.report');
+
+	Array.from(ratingLinks).forEach(function(element) {
+		element.addEventListener('click', function(e) {
+			e.preventDefault();
+		});
+	});
+}
+
+function initComments() {
+	addReportEventListeners();
+}
+
+document.addEventListener('DOMContentLoaded', initReports);

--- a/static/js/components/reports.js
+++ b/static/js/components/reports.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-function addRatingsEventListeners() {
+function addReportEventListeners() {
 	var ratingLinks = document.querySelectorAll('.report');
 
 	Array.from(ratingLinks).forEach(function(element) {
@@ -10,7 +10,7 @@ function addRatingsEventListeners() {
 	});
 }
 
-function initComments() {
+function initReports() {
 	addReportEventListeners();
 }
 

--- a/views/admin/createDebateType.hbs
+++ b/views/admin/createDebateType.hbs
@@ -61,7 +61,6 @@
 					<div id="msg_error" class="error o-forms__errortext hide" data-validation="tags"></div>
 				</div>
 				<div class="o-forms">
-					<input type="hidden" name="createdBy" value="{{username}}" />
 					<button type="submit" class="o-buttons o-buttons--primary" id="submit_new_debate">Create new
 						debate</button>
 				</div>

--- a/views/partials/components/comments/list.hbs
+++ b/views/partials/components/comments/list.hbs
@@ -1,5 +1,5 @@
 {{#each comments}}
 <div class="comments-{{../listStyleClass}}">
-	{{> components/comments/single class=this.tags comment=this debateId=../debateId debateType=../debateType repliesOpen=../repliesOpen listStyleClass=../listStyleClass currentUser=../currentUser }}
+	{{> components/comments/single class=this.tags comment=this debateId=../debateId debateType=../debateType repliesOpen=../repliesOpen listStyleClass=../listStyleClass currentUser=../currentUser  userRatingId=userRatingId }}
 </div>
 {{/each}}

--- a/views/partials/components/comments/single.hbs
+++ b/views/partials/components/comments/single.hbs
@@ -6,13 +6,14 @@
 		{{#if repliesOpen}}
 		<a data-comment-id="{{comment.id}}" class="reply" href="#">Reply</a>
 		|
-		{{#ifInList currentUser upVoters}}
-		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-index="{{index}}" data-rating="upvote"
-			class="rate" href="#">Up Vote</a>
+		{{#if userRatingId }}
+		<a data-debate-id="{{debateId}}" data-index="{{index}}" data-username={{currentUser}}
+			data-comment-id="{{comment.id}}" data-rating-id="{{userRatingId}}" class="rate-remove" href="#">Remove
+			UpVote</a>
 		{{else}}
-		<a data-debate-id="{{debateId}}" data-index="{{index}}" data-username={{currentUser}} class="rate-remove"
-			href="#">Remove UpVote</a>
-		{{/ifInList}}
+		<a data-debate-id="{{debateId}}" data-debate-type="{{debateType}}" data-comment-id="{{comment.id}}"
+			data-rating="upvote" class="rate" href="#">Up Vote</a>
+		{{/if}}
 		|
 		{{/if}}
 		<a data-comment-id="{{comment.id}}" class="report" href="#">Report</a>

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -17,6 +17,7 @@
 
 {{#if comments}}
 <script src="/static/js/components/comments.js"></script>
+<script src="/static/js/components/reports.js"></script>
 {{/if}}
 
 {{#if type}}


### PR DESCRIPTION
## Description

Through our work on order order we have noticed that storing the data as an indexed list has had its limitations. Looking up specific elements in the debate entry structure is difficult and has mostly required hacky solutions when updating and deleting. On a personal project I have implemented maps rather than lists and it was working really well, so i've decided to implement it here.

## Implementation

Although I have had to edit some of the implementation in certain files I mostly wanted to keep the data in an array when it is retrieved from the database because I sill thin an array is preferable for the app. To do this I have just added a normalise data function to the `dynamoDb.js` file. 

The main changes are in the update function where I have added a new way of updating nested attributes. But also made changes to upvoting and added the rating id being passed down if the user has rated that comment so it can be removed using that ID.

This has enabled me to be able to fix hacky implementations like having to look up comments from the index.

## Additional requirements

We will have to remove all db entries with the old structure. I could make it backwards compatible but I think we don't have any important data we want to keep.

## How to see it working

You can use `Testing new DB structure` debate or create a new one on this branch.

![Alt Text](https://media.tenor.com/images/7ee52af8e1838b5c4e17a955ac9f7972/tenor.gif)